### PR TITLE
Add customizable installation directory for browser shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This removes the installation but keeps any browser apps you've created.
 
 2. Follow the interactive prompts:
    - **Browser selection**: Automatically detects installed Chromium browsers
+   - **Installation directory**: Where to place browser shortcuts (defaults to `~/dev-browsers`)
    - **App name**: "Dev Environment", "Staging", etc. 
    - **Profile name**: Auto-suggested from app name (customizable)
    - **DNS rules**: Enter hostname-to-IP mappings (one per line)
@@ -79,6 +80,10 @@ This removes the installation but keeps any browser apps you've created.
 ```
 🌐 Using detected browser: Brave Browser
 
+📁 Where would you like to place your browser shortcuts?
+   Default: ~/dev-browsers
+   Installation directory (press Enter for default): 
+
 📱 App name: Dev Environment
 📁 Profile directory name:
    Suggested: 'dev-environment' (press Enter to use this)
@@ -92,7 +97,7 @@ This removes the installation but keeps any browser apps you've created.
 ✅ Create app? (Y/n): 
 ```
 
-This creates "Dev Environment.app" that:
+This creates "Dev Environment.app" in `~/dev-browsers/` that:
 - Launches Brave Browser with a separate profile
 - Redirects `example.com` → `192.168.1.100`  
 - Redirects `api.example.com` → `192.168.1.101`
@@ -124,6 +129,7 @@ This creates "Dev Environment.app" that:
 
 - ✅ **Multi-browser support**: Auto-detects Chrome, Brave, Edge, Vivaldi, Opera, Arc
 - ✅ **Smart defaults**: Auto-suggests profile names from app names  
+- ✅ **Organized storage**: Defaults to `~/dev-browsers` directory for easy management
 - ✅ **Interactive setup**: Guided prompts with input validation
 - ✅ **Multiple DNS rules**: Support for complex routing scenarios
 - ✅ **Separate profiles**: Isolated from your main browser data

--- a/make-dev-browser.sh
+++ b/make-dev-browser.sh
@@ -310,7 +310,25 @@ suggest_profile_name() {
 select_browser
 echo
 
-# Step 2: Get app name from user (with validation)
+# Step 2: Ask where to place browser shortcuts
+echo "📁 Where would you like to place your browser shortcuts?"
+echo "   Default: ~/dev-browsers"
+read -p "   Installation directory (press Enter for default): " INSTALL_DIR
+
+# If user just pressed Enter, use the default
+if [[ -z "$INSTALL_DIR" ]]; then
+    INSTALL_DIR="$HOME/dev-browsers"
+else
+    # Expand tilde in user-provided path
+    INSTALL_DIR="${INSTALL_DIR/#\~/$HOME}"
+fi
+
+# Create the installation directory if it doesn't exist
+mkdir -p "$INSTALL_DIR"
+echo "✓ Using installation directory: $INSTALL_DIR"
+echo
+
+# Step 3: Get app name from user (with validation)
 while true; do
     read -p "📱 App name (e.g., 'Chrome Dev'): " APP_NAME
     
@@ -381,6 +399,7 @@ read -p "🎨 Custom icon path (optional, press Enter to skip): " ICON_PATH
 echo
 echo "📋 Summary:"
 echo "   App Name: $APP_NAME"
+echo "   Install Location: $INSTALL_DIR/$APP_NAME.app"
 echo "   Profile: chrome-profiles/$PROFILE_NAME"
 echo "   DNS Rules: ${#DNS_RULES[@]} rule(s)"
 for rule in "${DNS_RULES[@]}"; do
@@ -397,8 +416,8 @@ if [[ "$confirm" =~ ^[Nn]$ ]]; then
     exit 0
 fi
 
-# Generate app bundle
-APP_BUNDLE="$APP_NAME.app"
+# Generate app bundle in the specified installation directory
+APP_BUNDLE="$INSTALL_DIR/$APP_NAME.app"
 APP_DIR="$APP_BUNDLE/Contents"
 MACOS_DIR="$APP_DIR/MacOS"
 RESOURCES_DIR="$APP_DIR/Resources"


### PR DESCRIPTION
## Summary
- Add prompt asking users where to place browser shortcuts with default to `~/dev-browsers`
- Support tilde expansion for user-provided paths  
- Automatically create installation directory if it doesn't exist
- Update documentation to reflect new installation directory feature

## Changes Made
### Script Updates (`make-dev-browser.sh`)
- Added installation directory prompt after browser selection
- Default to `~/dev-browsers` if user presses Enter
- Expand tilde (`~`) in user-provided paths to full home directory path
- Create installation directory automatically with `mkdir -p`
- Update app bundle creation to use specified directory instead of current working directory
- Show full installation path in summary before confirmation

### Documentation Updates (`README.md`)
- Added installation directory step to interactive prompts list
- Updated example output to show the new prompt
- Updated result description to mention `~/dev-browsers` location
- Added "Organized storage" to features list

## Benefits
- **Better organization**: Browser shortcuts are grouped in a dedicated directory
- **User choice**: Users can specify their preferred location
- **Smart default**: `~/dev-browsers` provides a sensible default location
- **Backward compatible**: No breaking changes to existing functionality

## Test plan
- [x] Verify default behavior works (pressing Enter uses `~/dev-browsers`)
- [x] Verify custom path behavior works (e.g., `~/my-apps`)
- [x] Verify tilde expansion works correctly
- [x] Verify directory creation works for non-existing paths
- [x] Verify summary shows correct installation location
- [x] Verify app bundle is created in specified directory

🤖 Generated with [Claude Code](https://claude.ai/code)